### PR TITLE
회원가입 페이지 개선

### DIFF
--- a/src/api/RegisterUser.ts
+++ b/src/api/RegisterUser.ts
@@ -14,18 +14,20 @@ export async function registerUser(body: any): Promise<any> {
   });
 
   const result = await response.json();
+
   if (!response.ok) {
-    throw new Error(result.message || '회원가입 요청 실패');
+    throw result; // 서버에서 온 에러 메시지를 직접 던짐
   }
+
   return result;
 }
 
 /**
  * 이메일 인증을 수행하는 함수
- * 
+ *
  * 주어진 userId와 validationNumber를 사용하여 이메일 인증 요청을 서버로 보냄
  * 서버 응답을 JSON으로 파싱하고, 응답이 실패할 경우 예외를 던짐
- * 
+ *
  * @param {number} userId - 인증할 사용자의 고유 ID
  * @param {number} validationNumber - 사용자가 입력한 인증 번호
  * @returns {Promise<any>} - 서버 응답의 JSON 데이터
@@ -50,8 +52,10 @@ export async function validateEmail(
   });
 
   const result = await response.json();
+
   if (!response.ok) {
-    throw new Error(result.message || '이메일 인증 실패');
+    throw result; // 서버에서 온 에러 메시지를 직접 던짐
   }
+
   return result;
 }

--- a/src/component/form/SignUpForm.tsx
+++ b/src/component/form/SignUpForm.tsx
@@ -3,90 +3,121 @@ import DaumPost from '@/api/DaumPost';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 
+/**
+ * 회원가입 폼 컴포넌트
+ *
+ * @param {Object} props - 컴포넌트 속성
+ * @param {Function} props.setEmail - 이메일을 설정하는 함수
+ * @param {Function} props.setPassword - 비밀번호를 설정하는 함수
+ * @param {Function} props.setPasswordValidate - 비밀번호 확인을 설정하는 함수
+ * @param {Function} props.setNickname - 닉네임을 설정하는 함수
+ * @param {Function} props.setLocation - 위치 정보를 설정하는 함수
+ * @param {string} props.password - 입력된 비밀번호 값
+ * @param {string} props.passwordValidate - 비밀번호 확인 값
+ * @param {Function} props.isPasswordValid - 비밀번호 유효성 검사 함수
+ * @returns {JSX.Element} 회원가입 폼 JSX 컴포넌트
+ */
 function SignUpForm({
   setEmail,
   setPassword,
   setPasswordValidate,
   setNickname,
   setLocation,
+  password,
+  passwordValidate,
+  isPasswordValid,
 }: {
   setEmail: (email: string) => void;
   setPassword: (password: string) => void;
   setPasswordValidate: (passwordValidate: string) => void;
   setNickname: (nickname: string) => void;
   setLocation: (location: string) => void;
+  password: string;
+  passwordValidate: string;
+  isPasswordValid: (password: string) => boolean;
 }) {
   const [zoneCode, setZoneCode] = useState<string>('');
   const [address, setAddress] = useState<string>('');
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <>
-      <form className="flex flex-col items-center gap-5 pt-12">
-        <div className="grid w-full max-w-lg items-center gap-2">
-          <Label htmlFor="email" className="text-start font-bold text-base">
-            Email
-          </Label>
-          <Input
-            type="email"
-            id="email"
-            placeholder="Email"
-            onChange={(e) => setEmail(e.target.value)}
-          />
-        </div>
-
-        <div className="grid w-full max-w-lg items-center gap-2">
-          <Label htmlFor="password" className="text-start font-bold text-base">
-            Password
-          </Label>
-          <Input
-            type="password"
-            id="password"
-            placeholder="Password"
-            onChange={(e) => setPassword(e.target.value)}
-          />
-        </div>
-
-        <div className="grid w-full max-w-lg items-center gap-2">
-          <Label
-            htmlFor="passwordValidate"
-            className="text-start font-bold text-base"
-          >
-            Password-Validation
-          </Label>
-          <Input
-            type="password"
-            id="passwordValidate"
-            placeholder="Password-Validation"
-            onChange={(e) => setPasswordValidate(e.target.value)}
-          />
-        </div>
-
-        <div className="grid w-full max-w-lg items-center gap-2">
-          <Label htmlFor="NickName" className="text-start font-bold text-base">
-            NickName
-          </Label>
-          <Input
-            type="text"
-            id="NickName"
-            placeholder="NickName"
-            onChange={(e) => setNickname(e.target.value)}
-          />
-        </div>
-
-        <DaumPost
-          isOpen={isOpen}
-          setIsOpen={setIsOpen}
-          zoneCode={zoneCode}
-          setZoneCode={setZoneCode}
-          address={address}
-          setAddress={(newAddress) => {
-            setAddress(newAddress);
-            setLocation(newAddress);
-          }}
+    <form className="flex flex-col items-center gap-5 pt-12">
+      {/* 이메일 입력 */}
+      <div className="grid w-full max-w-lg items-center gap-2">
+        <Label htmlFor="email" className="text-start font-bold text-base">
+          Email
+        </Label>
+        <Input
+          type="email"
+          id="email"
+          placeholder="Email"
+          onChange={(e) => setEmail(e.target.value)}
         />
-      </form>
-    </>
+      </div>
+
+      {/* 비밀번호 입력 */}
+      <div className="grid w-full max-w-lg items-center gap-2">
+        <Label htmlFor="password" className="text-start font-bold text-base">
+          Password
+        </Label>
+        <Input
+          type="password"
+          id="password"
+          placeholder="Password"
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        {!isPasswordValid(password) && password && (
+          <p className="text-red-500 text-sm">
+            비밀번호는 문자, 숫자, 특수문자를 포함한 8-20자여야 합니다.
+          </p>
+        )}
+      </div>
+
+      {/* 비밀번호 확인 */}
+      <div className="grid w-full max-w-lg items-center gap-2">
+        <Label
+          htmlFor="passwordValidate"
+          className="text-start font-bold text-base"
+        >
+          Password-Validation
+        </Label>
+        <Input
+          type="password"
+          id="passwordValidate"
+          placeholder="Password-Validation"
+          onChange={(e) => setPasswordValidate(e.target.value)}
+        />
+        {passwordValidate && password !== passwordValidate && (
+          <p className="text-red-500 text-sm">비밀번호가 일치하지 않습니다.</p>
+        )}
+      </div>
+
+      {/* 닉네임 입력 */}
+      <div className="grid w-full max-w-lg items-center gap-2">
+        <Label htmlFor="NickName" className="text-start font-bold text-base">
+          NickName
+        </Label>
+        <Input
+          type="text"
+          id="NickName"
+          placeholder="NickName"
+          onChange={(e) => setNickname(e.target.value)}
+        />
+      </div>
+
+      {/* 주소 입력 (DaumPost API 연동) */}
+      <DaumPost
+        isOpen={isOpen}
+        setIsOpen={setIsOpen}
+        zoneCode={zoneCode}
+        setZoneCode={setZoneCode}
+        address={address}
+        setAddress={(newAddress) => {
+          setAddress(newAddress);
+          setLocation(newAddress);
+        }}
+      />
+    </form>
   );
 }
 

--- a/src/components/ui/InputValidation.tsx
+++ b/src/components/ui/InputValidation.tsx
@@ -1,5 +1,4 @@
 import { REGEXP_ONLY_DIGITS_AND_CHARS } from 'input-otp';
-
 import {
   InputOTP,
   InputOTPGroup,
@@ -8,11 +7,26 @@ import {
 import { useState } from 'react';
 import ButtonProps from '@/component/ui/ButtonProps';
 import { validateEmail } from '@/api/RegisterUser';
-import { useNavigate } from 'react-router-dom';
+import CustomModal from '@/component/ui/CustomModal';
+/**
+ * 인증번호 입력 및 확인 컴포넌트
+ *
+ * @param {Object} props - 컴포넌트 속성
+ * @param {number} props.userId - 인증할 사용자 ID
+ * @param {Function} props.onVerified - 인증 상태를 전달하는 콜백 함수
+ * @returns {JSX.Element} 인증번호 입력 및 확인 JSX 컴포넌트
+ */
 
-function InputValidation({ userId }: { userId: number }) {
+function InputValidation({
+  userId,
+  onVerified,
+}: {
+  userId: number;
+  onVerified: (isVerified: boolean) => void;
+}) {
   const [otp, setOtp] = useState<string>('');
-  const navigate = useNavigate(); // useNavigate 훅 사용
+  const [showModal, setShowModal] = useState(false);
+  const [modalMessage, setModalMessage] = useState<string>('');
 
   const handleChange = (value: string) => {
     const numericValue = value.replace(/\D/g, '');
@@ -21,21 +35,34 @@ function InputValidation({ userId }: { userId: number }) {
     }
   };
 
-  const handleSubmit = async () => {
-    if (otp.length === 6) {
-      try {
-        console.log(userId);
-        const result = await validateEmail(userId, parseInt(otp, 10));
-        console.log('이메일 인증 성공:', result);
-
-        // 이메일 인증 성공 후 /login 페이지로 리디렉션
-        navigate('/login');
-      } catch (error) {
-        console.error('이메일 인증 실패:', error);
-      }
-    } else {
-      console.log('Invalid OTP');
+  const handleConfirm = async () => {
+    if (!otp) {
+      setModalMessage('인증번호를 입력해주세요.');
+      setShowModal(true);
+      return;
     }
+
+    if (otp.length !== 6) {
+      setModalMessage('인증번호는 6자리여야 합니다.');
+      setShowModal(true);
+      return;
+    }
+
+    try {
+      const validationNumber = parseInt(otp, 10);
+      await validateEmail(userId, validationNumber);
+      onVerified(true); // 인증 성공 시 상태 전달
+      setModalMessage('인증이 완료되었습니다.');
+      setShowModal(true);
+    } catch (error: any) {
+      onVerified(false); // 인증 실패 시 상태 전달
+      setModalMessage(error.MESSAGE || '알 수 없는 오류가 발생했습니다.');
+      setShowModal(true);
+    }
+  };
+
+  const handleCloseModal = () => {
+    setShowModal(false);
   };
 
   return (
@@ -77,9 +104,17 @@ function InputValidation({ userId }: { userId: number }) {
           size="lg"
           variant="color"
           title="Confirm"
-          onClick={handleSubmit}
+          onClick={handleConfirm}
         />
       </div>
+      {showModal && (
+        <CustomModal
+          title="알림"
+          description={modalMessage}
+          confirmText="확인"
+          onConfirm={handleCloseModal}
+        />
+      )}
     </>
   );
 }

--- a/src/pages/EmailVerify.tsx
+++ b/src/pages/EmailVerify.tsx
@@ -1,10 +1,25 @@
 import LoginTitle from '@/component/text/LoginTitle';
 import ButtonProps from '@/component/ui/ButtonProps';
-import InputValidation from '@/components/ui/InputValidation';
 import HeaderBack from '@/layout/HeaderBack';
-import { useLocation } from 'react-router-dom';
-
-const EmailBox = ({ userId }: { userId: number }) => {
+import { useLocation, useNavigate } from 'react-router-dom';
+import { useState } from 'react';
+import CustomModal from '@/component/ui/CustomModal';
+import InputValidation from '@/components/ui/InputValidation';
+/**
+ * 이메일 인증 입력 박스 컴포넌트
+ *
+ * @param {Object} props - 컴포넌트 속성
+ * @param {number} props.userId - 인증할 사용자 ID
+ * @param {Function} props.onVerified - 인증 상태를 전달하는 콜백 함수
+ * @returns {JSX.Element} 인증번호 입력 박스 JSX 컴포넌트
+ */
+const EmailBox = ({
+  userId,
+  onVerified,
+}: {
+  userId: number;
+  onVerified: (isVerified: boolean) => void;
+}) => {
   return (
     <div className="flex justify-center pt-16 px-[28px]">
       <div className="flex flex-col border border-solid border-gray-200 rounded-xl shadow-lg hover:shadow-2xl transition-shadow duration-300 w-full h-[350px] cursor-pointer">
@@ -14,16 +29,55 @@ const EmailBox = ({ userId }: { userId: number }) => {
           </h2>
           <p className="font-bold text-base">인증을 위해 아래에 입력해주세요</p>
         </div>
-        <InputValidation userId={userId} /> {/* userId 전달 */}
+        <InputValidation userId={userId} onVerified={onVerified} />{' '}
+        {/* userId와 인증 상태 전달 */}
       </div>
     </div>
   );
 };
 
+/**
+ * 이메일 인증 완료 페이지 컴포넌트
+ *
+ * @returns {JSX.Element} 이메일 인증 완료 페이지 JSX 컴포넌트
+ */
 function EmailVerify() {
   const location = useLocation();
   const { userId } = location.state; // 회원가입 페이지에서 넘겨준 userId
-  console.log(userId);
+  const [isVerified, setIsVerified] = useState(false);
+  const [showModal, setShowModal] = useState(false);
+  const [modalMessage, setModalMessage] = useState('');
+  const navigate = useNavigate();
+
+  /**
+   * 인증 상태를 업데이트하는 함수
+   *
+   * @param {boolean} status - 인증 성공 여부
+   */
+  const handleVerified = (status: boolean) => {
+    setIsVerified(status);
+  };
+
+  /**
+   * 인증 완료 버튼 클릭 시 호출되는 함수
+   * 인증이 완료되지 않았을 경우 모달로 알림,
+   * 완료된 경우 로그인 페이지로 이동
+   */
+  const handleComplete = () => {
+    if (!isVerified) {
+      setModalMessage('인증이 완료되지 않았습니다.');
+      setShowModal(true);
+    } else {
+      navigate('/login');
+    }
+  };
+  
+  /**
+   * 모달을 닫는 함수
+   */
+  const handleCloseModal = () => {
+    setShowModal(false);
+  };
 
   return (
     <div className="h-full flex flex-col">
@@ -32,10 +86,23 @@ function EmailVerify() {
         title="이메일 인증"
         subTitle="회원 가입에 필요한 이메일을 인증해주세요"
       />
-      <EmailBox userId={userId} /> {/* userId 전달 */}
+      <EmailBox userId={userId} onVerified={handleVerified} />
       <div className="flex justify-center pt-20">
-        <ButtonProps size="login" variant="custom" title="완료" />
+        <ButtonProps
+          size="login"
+          variant="custom"
+          title="완료"
+          onClick={handleComplete}
+        />
       </div>
+      {showModal && (
+        <CustomModal
+          title="알림"
+          description={modalMessage}
+          confirmText="확인"
+          onConfirm={handleCloseModal}
+        />
+      )}
     </div>
   );
 }

--- a/src/pages/SignInfo.tsx
+++ b/src/pages/SignInfo.tsx
@@ -4,8 +4,14 @@ import ButtonProps from '@/component/ui/ButtonProps';
 import HeaderBack from '@/layout/HeaderBack';
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { registerUser } from '@/api/RegisterUser'; // 회원가입 API
+import { registerUser } from '@/api/RegisterUser';
+import CustomModal from '@/component/ui/CustomModal';
 
+/**
+ * 회원 정보 입력 페이지 컴포넌트
+ *
+ * @returns {JSX.Element} 회원 정보 입력 페이지 JSX 컴포넌트
+ */
 function SignInfo() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -14,30 +20,71 @@ function SignInfo() {
   const [location, setLocation] = useState('');
   const [role, setRole] = useState('ROLE_GUEST'); // 기본값 설정
 
+  const [showModal, setShowModal] = useState(false);
+  const [modalMessage, setModalMessage] = useState(''); // 모달에 표시할 오류 메시지
+
   const navigate = useNavigate();
 
+   /**
+   * 비밀번호 유효성 검사 함수
+   *
+   * @param {string} password - 검사할 비밀번호 문자열
+   * @returns {boolean} 비밀번호가 유효한지 여부를 반환
+   */
+  const isPasswordValid = (password: string) => {
+    const regex =
+      /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]{8,20}$/;
+    return regex.test(password);
+  };
+
+   /**
+   * 'Next' 버튼 클릭 시 호출되는 함수
+   * 유효성 검사 실패 시 모달로 오류 메시지 출력, 성공 시 회원가입 API 호출 후 이메일 인증 페이지로 이동
+   */
   const handleNextClick = async () => {
+    if (!email || !password || !passwordValidate || !nickname || !location) {
+      setModalMessage('필수 입력 항목을 확인해주세요.');
+      setShowModal(true);
+      return;
+    }
+
+    if (!isPasswordValid(password)) {
+      setModalMessage(
+        '비밀번호는 문자, 숫자, 특수문자를 포함한 8-20자로 설정해야 합니다.'
+      );
+      setShowModal(true);
+      return;
+    }
+
+    if (password !== passwordValidate) {
+      setModalMessage('비밀번호가 일치하지 않습니다.');
+      setShowModal(true);
+      return;
+    }
+
     try {
-      // 회원가입 요청 데이터
       const userData = {
         email,
-        role, // 역할 (호스트/게스트)
+        role,
         password,
         passwordValidate,
         location,
         nickname,
       };
-
-      // 회원가입 요청 및 이메일 인증번호 발송
       const response = await registerUser(userData);
-      // userId 추출
-      const userId = response.data.userId; // 응답에서 userId 가져옴
-
-      // 회원가입 성공 시 이메일 인증 페이지로 이동 (userId 함께 전달)
+      const userId = response.data.userId;
       navigate('/emailverify', { state: { userId } });
-    } catch (error) {
-      console.error('회원가입 요청 중 오류 발생:', error);
+    } catch (err: any) {
+      setModalMessage(err.MESSAGE || '알 수 없는 오류가 발생했습니다.');
+      setShowModal(true);
     }
+  };
+
+  /**
+   * 모달 닫기 함수
+   */
+  const handleCloseModal = () => {
+    setShowModal(false);
   };
 
   return (
@@ -53,6 +100,9 @@ function SignInfo() {
         setPasswordValidate={setPasswordValidate}
         setNickname={setNickname}
         setLocation={setLocation}
+        password={password}
+        passwordValidate={passwordValidate}
+        isPasswordValid={isPasswordValid}
       />
       <div className="pt-8 flex justify-center">
         <ButtonProps
@@ -62,6 +112,14 @@ function SignInfo() {
           onClick={handleNextClick}
         />
       </div>
+      {showModal && (
+        <CustomModal
+          title="회원가입 오류"
+          description={modalMessage}
+          confirmText="확인"
+          onConfirm={handleCloseModal}
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
- 입력 데이터 유효성 검증 추가 (8~20자의 영문, 대문자, 숫자가 포함된 비밀번호)
- 각 페이지마다 모달 이벤트 추가
  - 회원가입 페이지
    - 입력 데이터의 FE단 유효성 검증에 걸리거나, 서버에서 던져주는 에러 메시지를 모달로 띄우게끔 변경
    - 비밀번호 정규식에 위배되거나 Password-Validation이 일치하지 않을 시 경고 문구를 작게 띄우는 기능 추가

  - 이메일 인증 페이지 : 이메일 인증 칸을 비운 채로 인증을 시도하거나, 인증이 완료되지 않았는데 완료버튼을 누를 시 모달 띄움

close #6 