### PR TITLE
Fix/18 레이아웃 및 api 문제 해결

### DIFF
--- a/src/api/Login.ts
+++ b/src/api/Login.ts
@@ -28,39 +28,23 @@ export async function login(
   return response;
 }
 
-/**
- * 주어진 쿠키 이름에 해당하는 값을 반환하는 함수
- * @param {string} name - 가져올 쿠키의 이름
- * @returns {string | undefined} 쿠키 값 또는 undefined (undefined일 경우, 토큰이 없는 것)
- */
-export function getCookieValue(name: string): string | undefined {
-  const value = `; ${document.cookie}`;
-  const parts = value.split(`; ${name}=`);
-  if (parts.length === 2) return parts.pop()?.split(';').shift();
-}
 
 /**
  * 사용자 로그아웃 요청을 서버에 보내는 함수.
  * 이 함수는 쿠키에서 accessToken과 refreshToken을 추출하여
  * 해당 토큰들을 포함한 로그아웃 요청을 서버로 보냄
+ * 
+ * // 2024-11-13 쿠키 사용 제거
  *
  * @returns {Promise<MatchingRequestResult>} 서버의 응답 데이터가 담긴 Promise 객체
  * @throws {Error} 토큰이 없거나 요청이 실패할 경우 에러를 발생
  */
 export async function userLogout(): Promise<MatchingRequestResult> {
   const url = `http://localhost:8080/user/logout`;
-  const accessToken = getCookieValue('accessToken');
-  const refreshToken = getCookieValue('refreshToken');
-
-  if (!accessToken || !refreshToken) {
-    throw new Error('토큰이 존재하지 않습니다.');
-  }
   try {
     const response = await fetch(url, {
       method: 'POST',
       headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'X-Refresh-Token': refreshToken,
         'Content-Type': 'application/json',
       },
       credentials: 'include',

--- a/src/api/Notification.ts
+++ b/src/api/Notification.ts
@@ -1,4 +1,4 @@
-import { getRequest, deleteRequest } from '@/api/Request';
+import { getRequest, deleteRequest, patchRequest } from '@/api/Request';
 
 /**
  * 서버에서 알림 데이터를 GET 요청으로 불러오는 함수
@@ -29,4 +29,23 @@ export async function fetchDeleteNotifications(
   const url = `http://localhost:8080/notification?notificationId=${notificationId}`;
   const result = await deleteRequest(url);
   return result;
+}
+
+/**
+ * 모든 알림을 읽음 처리하는 함수
+ * @returns {Promise<any>} 서버로부터의 응답 데이터를 포함한 Promise
+ */
+export async function fetchReadAllNotifications(): Promise<any> {
+  const url = `http://localhost:8080/notification/read`;
+  const result = await patchRequest(url, {});
+  return result;
+}
+
+/**
+ * 읽지 않은 알림 개수를 조회하는 함수
+ * @returns {Promise<number>} 읽지 않은 알림 개수
+ */
+export async function fetchUnreadNotificationsCount(): Promise<number> {
+  const result = await getRequest('http://localhost:8080/notification/unread-alarms');
+  return result.data.unreadNotificationNum;
 }

--- a/src/api/Request.ts
+++ b/src/api/Request.ts
@@ -1,19 +1,15 @@
-import { getCookieValue} from './Login';
-
 export async function fetchWithToken(
   url: string,
   options: RequestInit = {}
 ): Promise<Response> {
-  const token = getCookieValue('accessToken');
   const headers = {
     ...options.headers,
-    Authorization: `Bearer ${token}`,
-    Credential: 'include',
   };
 
   let response = await fetch(url, {
     ...options,
     headers,
+    credentials: 'include',
   });
 
   // accessToken 만료되면 로그인 페이지로 이동

--- a/src/api/Sse.ts
+++ b/src/api/Sse.ts
@@ -1,22 +1,12 @@
 import { EventSourcePolyfill } from 'event-source-polyfill';
-import { getCookieValue } from '@/api/Login';
 
 export function connectSSE(
   onMessage: (event: MessageEvent) => void
 ): EventSource {
-  const accessToken = getCookieValue('accessToken');
-
-  if (!accessToken) {
-    console.error('인증 토큰이 없습니다.');
-    throw new Error('인증 토큰이 필요합니다.');
-  }
 
   const eventSource = new EventSourcePolyfill(
     `http://localhost:8080/notification/sse`,
     {
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-      },
       withCredentials: true,
       heartbeatTimeout: 60000,
       reconnectInterval: 3000,
@@ -42,19 +32,17 @@ export function connectSSE(
   eventSource.onerror = (error) => {
     console.error('SSE 연결 오류 발생:', error);
 
-    if (eventSource.readyState === EventSource.CLOSED || eventSource.readyState === EventSource.CONNECTING) {
+    if (
+      eventSource.readyState === EventSource.CLOSED ||
+      eventSource.readyState === EventSource.CONNECTING
+    ) {
       console.log('연결이 종료되거나 연결 중 문제 발생. 재연결 시도');
-      
+
       eventSource.close();
-      
+
       setTimeout(() => {
         try {
-          const newToken = getCookieValue('accessToken');
-          if (newToken) {
-            connectSSE(onMessage);
-          } else {
-            console.error('재연결을 위한 토큰이 없습니다.');
-          }
+          connectSSE(onMessage);
         } catch (reconnectError) {
           console.error('재연결 실패:', reconnectError);
         }

--- a/src/api/Sse.ts
+++ b/src/api/Sse.ts
@@ -2,8 +2,7 @@ import { EventSourcePolyfill } from 'event-source-polyfill';
 
 export function connectSSE(
   onMessage: (event: MessageEvent) => void
-): EventSource {
-
+): EventSourcePolyfill {
   const eventSource = new EventSourcePolyfill(
     `http://localhost:8080/notification/sse`,
     {
@@ -17,14 +16,11 @@ export function connectSSE(
     console.log('SSE 연결 성공');
   };
 
-  // NOTIFICATION 이벤트에 대한 리스너 추가
   eventSource.addEventListener('NOTIFICATION', (event) => {
     console.log('알림 이벤트 수신:', event.data);
-    // 서버에서 온 데이터를 직접 사용
     onMessage(new MessageEvent('message', { data: event.data }));
   });
 
-  // 하트비트 이벤트 리스너 추가
   eventSource.addEventListener('HEARTBEAT', () => {
     console.log('하트비트 수신');
   });
@@ -37,9 +33,10 @@ export function connectSSE(
       eventSource.readyState === EventSource.CONNECTING
     ) {
       console.log('연결이 종료되거나 연결 중 문제 발생. 재연결 시도');
-
+      
       eventSource.close();
 
+      // 재연결 시도
       setTimeout(() => {
         try {
           connectSSE(onMessage);
@@ -51,4 +48,8 @@ export function connectSSE(
   };
 
   return eventSource;
+}
+
+export function disconnectSSE() {
+  // 기존 연결 종료 로직
 }

--- a/src/component/form/SignUpForm.tsx
+++ b/src/component/form/SignUpForm.tsx
@@ -41,82 +41,88 @@ function SignUpForm({
   const [isOpen, setIsOpen] = useState(false);
 
   return (
-    <form className="flex flex-col items-center gap-5 pt-12">
-      {/* 이메일 입력 */}
-      <div className="grid w-full max-w-lg items-center gap-2">
-        <Label htmlFor="email" className="text-start font-bold text-base">
-          Email
-        </Label>
-        <Input
-          type="email"
-          id="email"
-          placeholder="Email"
-          onChange={(e) => setEmail(e.target.value)}
+    <form className="flex flex-col items-center gap-5 pt-8 px-4 max-w-lg mx-auto">
+      <div className="w-full space-y-4">
+        {/* 이메일 입력 */}
+        <div className="grid w-full items-center gap-2">
+          <Label htmlFor="email" className="text-start font-bold text-base">
+            Email
+          </Label>
+          <Input
+            type="email"
+            id="email"
+            placeholder="Email"
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full"
+          />
+        </div>
+
+        {/* 비밀번호 입력 */}
+        <div className="grid w-full items-center gap-2">
+          <Label htmlFor="password" className="text-start font-bold text-base">
+            Password
+          </Label>
+          <Input
+            type="password"
+            id="password"
+            placeholder="Password"
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full"
+          />
+          {!isPasswordValid(password) && password && (
+            <p className="text-red-500 text-sm">
+              비밀번호는 문자, 숫자, 특수문자를 포함한 8-20자여야 합니다.
+            </p>
+          )}
+        </div>
+
+        {/* 비밀번호 확인 */}
+        <div className="grid w-full items-center gap-2">
+          <Label
+            htmlFor="passwordValidate"
+            className="text-start font-bold text-base"
+          >
+            Password-Validation
+          </Label>
+          <Input
+            type="password"
+            id="passwordValidate"
+            placeholder="Password-Validation"
+            onChange={(e) => setPasswordValidate(e.target.value)}
+            className="w-full"
+          />
+          {passwordValidate && password !== passwordValidate && (
+            <p className="text-red-500 text-sm">비밀번호가 일치하지 않습니다.</p>
+          )}
+        </div>
+
+        {/* 닉네임 입력 */}
+        <div className="grid w-full items-center gap-2">
+          <Label htmlFor="NickName" className="text-start font-bold text-base">
+            NickName
+          </Label>
+          <Input
+            type="text"
+            id="NickName"
+            placeholder="NickName"
+            onChange={(e) => setNickname(e.target.value)}
+            className="w-full"
+          />
+        </div>
+
+        {/* 주소 입력 (DaumPost API 연동) */}
+        <DaumPost
+          isOpen={isOpen}
+          setIsOpen={setIsOpen}
+          zoneCode={zoneCode}
+          setZoneCode={setZoneCode}
+          address={address}
+          setAddress={(newAddress) => {
+            setAddress(newAddress);
+            setLocation(newAddress);
+          }}
         />
       </div>
-
-      {/* 비밀번호 입력 */}
-      <div className="grid w-full max-w-lg items-center gap-2">
-        <Label htmlFor="password" className="text-start font-bold text-base">
-          Password
-        </Label>
-        <Input
-          type="password"
-          id="password"
-          placeholder="Password"
-          onChange={(e) => setPassword(e.target.value)}
-        />
-        {!isPasswordValid(password) && password && (
-          <p className="text-red-500 text-sm">
-            비밀번호는 문자, 숫자, 특수문자를 포함한 8-20자여야 합니다.
-          </p>
-        )}
-      </div>
-
-      {/* 비밀번호 확인 */}
-      <div className="grid w-full max-w-lg items-center gap-2">
-        <Label
-          htmlFor="passwordValidate"
-          className="text-start font-bold text-base"
-        >
-          Password-Validation
-        </Label>
-        <Input
-          type="password"
-          id="passwordValidate"
-          placeholder="Password-Validation"
-          onChange={(e) => setPasswordValidate(e.target.value)}
-        />
-        {passwordValidate && password !== passwordValidate && (
-          <p className="text-red-500 text-sm">비밀번호가 일치하지 않습니다.</p>
-        )}
-      </div>
-
-      {/* 닉네임 입력 */}
-      <div className="grid w-full max-w-lg items-center gap-2">
-        <Label htmlFor="NickName" className="text-start font-bold text-base">
-          NickName
-        </Label>
-        <Input
-          type="text"
-          id="NickName"
-          placeholder="NickName"
-          onChange={(e) => setNickname(e.target.value)}
-        />
-      </div>
-
-      {/* 주소 입력 (DaumPost API 연동) */}
-      <DaumPost
-        isOpen={isOpen}
-        setIsOpen={setIsOpen}
-        zoneCode={zoneCode}
-        setZoneCode={setZoneCode}
-        address={address}
-        setAddress={(newAddress) => {
-          setAddress(newAddress);
-          setLocation(newAddress);
-        }}
-      />
     </form>
   );
 }

--- a/src/components/ui/alarmbox.tsx
+++ b/src/components/ui/alarmbox.tsx
@@ -1,7 +1,9 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import Alarm from '@/assets/Alarm.svg';
 import HeaderIcon from '@/component/ui/HeaderIcon';
 import { connectSSE } from '@/api/Sse';
+import { fetchUnreadNotificationsCount } from '@/api/Notification';
+import useNotificationStore from '@/store/NotificationStore';
 
 interface AlarmBoxProps {
   onClick: () => void;
@@ -25,27 +27,40 @@ export interface UserData {
  * @returns {JSX.Element} 알림 아이콘과 미리보기 박스를 표시하는 컴포넌트
  */
 function AlarmBox({ onClick }: AlarmBoxProps): JSX.Element {
-  const [hasNewNotification, setHasNewNotification] = useState<boolean>(false); // 새로운 알림이 있는지 여부
-  const [latestNotification, setLatestNotification] = useState<string>(''); // 최근 알림 메시지 저장
+  const [hasNewNotification, setHasNewNotification] = useState<boolean>(false);
+  const [latestNotification, setLatestNotification] = useState<string>('');
+  const [isVisible, setIsVisible] = useState<boolean>(false);
+  const { unreadCount, setUnreadCount } = useNotificationStore();
+
+  const timerRef = useRef<NodeJS.Timeout>();
+  const sseConnectionRef = useRef<EventSource | null>(null); // SSE 연결 상태 추적
+
+  const loadUnreadCount = async () => {
+    try {
+      const count = await fetchUnreadNotificationsCount();
+      setUnreadCount(count);
+    } catch (error) {
+      console.error('읽지 않은 알림 개수 로드 실패:', error);
+    }
+  };
 
   useEffect(() => {
-    let eventSource: EventSource | null = null;
+    loadUnreadCount();
 
-    const setupSSE = async () => {
+    const setupSSE = () => {
+      if (sseConnectionRef.current) return; // 이미 연결된 상태라면 중복 연결 방지
+
       try {
-        console.log('SSE 설정 시작');  // 디버깅용 로그
-        
-        const handleMessage = (event: MessageEvent) => {
+        const eventSource = connectSSE(async (event: MessageEvent) => {
           try {
             const newNotification = event.data;
-            setHasNewNotification(true);
-            setLatestNotification(newNotification);
+            showNotification(newNotification);
+            loadUnreadCount();
           } catch (parseError) {
+            console.error('SSE 메시지 파싱 실패:', parseError);
           }
-        };
-
-        eventSource = connectSSE(handleMessage);
-        console.log('SSE 연결 완료');  // 디버깅용 로그
+        });
+        sseConnectionRef.current = eventSource; // 연결을 추적
       } catch (error) {
         console.error('SSE 연결 실패:', error);
       }
@@ -53,44 +68,69 @@ function AlarmBox({ onClick }: AlarmBoxProps): JSX.Element {
 
     setupSSE();
 
-    // return () => {
-    //   if (eventSource) {
-    //     console.log('SSE 연결 종료');
-    //     eventSource.close();
-    //   }
-    // };
+    // cleanup: 컴포넌트가 언마운트되거나 재렌더링될 때 기존 SSE 연결 해제
+    return () => {
+      if (sseConnectionRef.current) {
+        sseConnectionRef.current.close();
+        sseConnectionRef.current = null;
+      }
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    };
   }, []);
 
-  useEffect(() => {
-    if (hasNewNotification) {
-      // 6초 후에 알림을 자동으로 닫음
-      const timer = setTimeout(() => {
-        setHasNewNotification(false);
-      }, 6000);
-
-      return () => clearTimeout(timer);
+  const showNotification = (message: string) => {
+    if (timerRef.current) {
+      clearTimeout(timerRef.current);
+      setHasNewNotification(false);
     }
-  }, [hasNewNotification]);
 
-  // 알림창(모달)이 열릴 때, 알림 미리보기 박스 숨기기
-  const handleIconClick = () => {
-    setHasNewNotification(false); // 미리보기 박스 숨기기
-    onClick(); // 상위 컴포넌트에서 모달 열기 처리
+    setLatestNotification(message);
+    setIsVisible(true);
+    setHasNewNotification(true);
+
+    timerRef.current = setTimeout(() => {
+      setHasNewNotification(false);
+      setTimeout(() => {
+        setIsVisible(false);
+      }, 700);
+    }, 3000);
+  };
+
+  const handleIconClick = async () => {
+    try {
+      onClick();
+    } catch (error) {
+      console.error('알림 처리 실패:', error);
+    }
   };
 
   return (
     <div className="relative">
-      <HeaderIcon src={Alarm} alt="Alarm" onClick={handleIconClick} />
+      <div className="relative">
+        <HeaderIcon src={Alarm} alt="Alarm" onClick={handleIconClick} />
+        {unreadCount > 0 && (
+          <div className="absolute -top-1 -right-1 bg-red-500 text-white rounded-full w-5 h-5 flex items-center justify-center text-xs">
+            {unreadCount > 99 ? '99+' : unreadCount}
+          </div>
+        )}
+      </div>
 
-      {/* 알림 메시지 컨테이너 */}
-      <div
-        className={`fixed top-0 left-0 right-0 flex justify-center transition-transform duration-700 ease-in-out ${
-          hasNewNotification ? 'translate-y-0' : '-translate-y-full'
-        }`}
-      >
-        <div className="bg-gradient-to-r from-blue-500 to-indigo-600 text-white border border-blue-600 shadow-lg rounded-b-lg px-6 py-4 mt-0 max-w-md transform hover:scale-102 transition-all">
+      <div className="fixed top-0 left-0 right-0 flex justify-center pointer-events-none overflow-hidden">
+        <div
+          className={`bg-gradient-to-r from-blue-500 to-indigo-600 text-white 
+            border border-blue-600 shadow-lg rounded-b-lg px-6 py-4 mt-0 max-w-md 
+            transform transition-all duration-700 ease-in-out`}
+          style={{
+            transform: `translateY(${isVisible ? '0' : '-100%'})`,
+            opacity: hasNewNotification ? '1' : '0',
+            pointerEvents: 'none',
+            position: 'relative',
+            top: 0,
+          }}
+        >
           <div className="flex items-center space-x-3">
-            {/* 알림 아이콘 */}
             <div className="flex-shrink-0">
               <svg
                 className="h-6 w-6 text-white animate-pulse"
@@ -104,8 +144,6 @@ function AlarmBox({ onClick }: AlarmBoxProps): JSX.Element {
                 <path d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9" />
               </svg>
             </div>
-            
-            {/* 알림 메시지 */}
             <div className="flex-1">
               <p className="text-sm font-bold tracking-wide">
                 {latestNotification}

--- a/src/layout/Header.tsx
+++ b/src/layout/Header.tsx
@@ -3,7 +3,7 @@ import Message from '@/assets/Message.svg';
 import { Link } from 'react-router-dom';
 import { ModalPortal } from '@/lib/ModalPortal';
 import { useState } from 'react';
-import Modal from '@/modal/Modal';
+import AlarmModal from '@/modal/AlarmModal';
 import HeaderIcon from '@/component/ui/HeaderIcon';
 import AlarmBox from '@/components/ui/alarmbox';
 
@@ -36,7 +36,7 @@ function Header() {
       </div>
       {isOpen && (
         <ModalPortal>
-          <Modal closeModal={closeModal} />
+          <AlarmModal closeModal={closeModal} />
         </ModalPortal>
       )}
     </header>

--- a/src/modal/AlarmModal.tsx
+++ b/src/modal/AlarmModal.tsx
@@ -1,12 +1,26 @@
 import { useEffect } from 'react';
 import AlarmList from '@/component/AlarmList';
+import { fetchReadAllNotifications } from '@/api/Notification';
+import useNotificationStore from '@/store/NotificationStore';
 
-function Modal({ closeModal }: { closeModal: () => void }) {
-  // Esc 버튼을 눌렀을 때 모달을 닫는 기능 추가
+function AlarmModal({ closeModal }: { closeModal: () => void }) {
+  const { resetUnreadCount } = useNotificationStore();
+  const handleClose = async () => {
+    try {
+      await fetchReadAllNotifications(); // 모든 알림 읽음 처리
+      resetUnreadCount();
+      closeModal();
+    } catch (error) {
+      console.error('알림 읽음 처리 실패:', error);
+      closeModal();
+    }
+  };
+
+  // Esc 버튼을 눌렀을 때 모달을 닫는 기능
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       if (event.key === 'Escape') {
-        closeModal();
+        handleClose();
       }
     };
 
@@ -19,18 +33,18 @@ function Modal({ closeModal }: { closeModal: () => void }) {
   // 모달 바깥쪽을 클릭했을 때 모달을 닫는 함수
   const handleOutsideClick = (event: React.MouseEvent<HTMLDivElement>) => {
     if (event.target === event.currentTarget) {
-      closeModal();
+      handleClose();
     }
   };
 
   return (
     <div
       className="fixed top-0 left-0 w-full h-full flex justify-center items-center bg-black bg-opacity-50"
-      onClick={handleOutsideClick} // 바깥쪽 클릭 감지
+      onClick={handleOutsideClick}
     >
       <div className="signUpBg w-[500px] h-auto p-6 rounded-lg relative">
         <button
-          onClick={closeModal}
+          onClick={handleClose}
           className="absolute top-3 right-3 text-xl font-bold text-gray-600 hover:text-gray-800"
         >
           &times;
@@ -44,4 +58,4 @@ function Modal({ closeModal }: { closeModal: () => void }) {
   );
 }
 
-export default Modal;
+export default AlarmModal;

--- a/src/pages/SignInfo.tsx
+++ b/src/pages/SignInfo.tsx
@@ -88,29 +88,33 @@ function SignInfo() {
   };
 
   return (
-    <div className="h-full flex flex-col">
-      <HeaderBack />
-      <LoginTitle
-        title="회원 정보 입력"
-        subTitle="회원 가입에 필요한 정보를 입력해주세요"
-      />
-      <SignUpForm
-        setEmail={setEmail}
-        setPassword={setPassword}
-        setPasswordValidate={setPasswordValidate}
-        setNickname={setNickname}
-        setLocation={setLocation}
-        password={password}
-        passwordValidate={passwordValidate}
-        isPasswordValid={isPasswordValid}
-      />
-      <div className="pt-8 flex justify-center">
-        <ButtonProps
-          size="login"
-          variant="custom"
-          title="Next"
-          onClick={handleNextClick}
-        />
+    <div className="min-h-screen flex flex-col bg-white">
+      <HeaderBack /> 
+      <div className="flex-1 overflow-y-auto">
+        <div className="container mx-auto px-4 max-w-2xl">
+          <LoginTitle
+            title="회원 정보 입력"
+            subTitle="회원 가입에 필요한 정보를 입력해주세요"
+          />
+          <SignUpForm
+            setEmail={setEmail}
+            setPassword={setPassword}
+            setPasswordValidate={setPasswordValidate}
+            setNickname={setNickname}
+            setLocation={setLocation}
+            password={password}
+            passwordValidate={passwordValidate}
+            isPasswordValid={isPasswordValid}
+          />
+          <div className="flex justify-center my-8">
+            <ButtonProps
+              size="login"
+              variant="custom"
+              title="Next"
+              onClick={handleNextClick}
+            />
+          </div>
+        </div>
       </div>
       {showModal && (
         <CustomModal

--- a/src/store/NotificationStore.ts
+++ b/src/store/NotificationStore.ts
@@ -1,0 +1,18 @@
+import { create } from 'zustand';
+
+interface NotificationState {
+  unreadCount: number;
+  setUnreadCount: (count: number) => void;
+  incrementUnreadCount: () => void;
+  resetUnreadCount: () => void;
+}
+
+const useNotificationStore = create<NotificationState>((set) => ({
+  unreadCount: 0,
+  setUnreadCount: (count) => set({ unreadCount: count }),
+  incrementUnreadCount: () =>
+    set((state) => ({ unreadCount: state.unreadCount + 1 })),
+  resetUnreadCount: () => set({ unreadCount: 0 }),
+}));
+
+export default useNotificationStore;


### PR DESCRIPTION
## 서버 인증 로직 수정에 따른 함수 변경
- `getCookieValue` 함수 삭제 : 쿠키의 `httpOnly` 플래그 활성화로 더 이상 브라우저에서 쿠키의 값을 읽을 수 없으므로
- 모든 요청에 `credentials : 'include'` 포함 : 자격 증명을 포함해야 서버에서 쿠키를 읽을 수 있음
- 모든 요청의 헤더에 `Authorization` 삭제 : 쿠키만 보내면 서버에서 토큰 유효성을 알아서 검증함
- EventSourcePolyFill에 헤더를 포함하던 부분 삭제

## 회원가입 페이지 수정
- 레이아웃의 어색함 수정

## 알림 기능 대거 추가
- 알림 아이콘에 읽지 않은 알림의 개수가 표시됨, 읽지 않은 알림은 서버에 요청을 보내 확인
  - 알림 모달을 닫으면 모든 알림이 읽음 처리되고, 이 또한 API Call로 처리
- 읽지 않은 알림은 알림 리스트에서 구분되게 처리
- AlarmBox가 Fix되어 있어 삐져나오던 문제 개선
- 알림 삭제할 때 애니메이션 적용
- SSE 연결 중복 문제 제거
- Modal.tsx => AlarmModal.tsx 파일명 Rename
- 알림 개수 상태를 관리하기 위한 `NotificationStore.ts` 추가