### PR TITLE
#29 UX 개선

### DIFF
--- a/src/component/card/MyPageCard.tsx
+++ b/src/component/card/MyPageCard.tsx
@@ -45,7 +45,10 @@ function MyPageCard() {
 
   const titles: Title[] = [
     { label: 'History', component: ({ label }) => <History title={label} /> },
-    { label: 'Question', component: ({ label }) => <Question title={label} /> },
+    {
+      label: 'Question',
+      component: ({ label }) => <Question title={label} setView={setView} />,
+    },
     {
       label: '장소 수정',
       component: ({ label }) => <PlaceEdit title={label} />,

--- a/src/component/form/NoteSendForm.tsx
+++ b/src/component/form/NoteSendForm.tsx
@@ -11,7 +11,7 @@ import { fetchNoteReceiver, fetchNoteSend } from '@/api/Note';
 import { useState } from 'react';
 import ButtonProps from '../ui/ButtonProps';
 
-function NoteSendForm() {
+function NoteSendForm({ closeModal }: { closeModal: () => void }) {
   const [title, setTitle] = useState<string>('');
   const [content, setContent] = useState<string>('');
   const [receiverId, setReceiverId] = useState<number | null>(null);
@@ -26,12 +26,15 @@ function NoteSendForm() {
     mutationFn: (noteData: NoteSendRequest) => fetchNoteSend(noteData),
     onSuccess: (data) => {
       console.log('Note sent successfully:', data);
+      alert('쪽지가 성공적으로 전송되었습니다!'); // 성공 여부 alert로 띄워주기
       setReceiverId(null);
       setTitle('');
       setContent('');
+      closeModal(); // 쪽지 전송 후 받은 쪽지함으로 이동
     },
     onError: (error) => {
       console.error('Error sending note:', error);
+      alert('쪽지 전송에 실패하였습니다!');
     },
   });
 

--- a/src/component/form/QuestionForm.tsx
+++ b/src/component/form/QuestionForm.tsx
@@ -2,23 +2,30 @@ import { useState } from 'react';
 import { FormGroup } from './GuestRegistForm';
 import { Input } from '@/components/ui/input';
 import { Textarea } from '@/components/ui/textarea';
-import { QuestionPost } from '@/interface/QuestionInterface';
+import {
+  QuestionFormProps,
+  QuestionPost,
+  QuestionResponse,
+} from '@/interface/QuestionInterface';
 import { useMutation } from '@tanstack/react-query';
 import { fetchQuestionPost } from '@/api/Question';
 import ButtonProps from '../ui/ButtonProps';
 
-function QuestionForm() {
+function QuestionForm({ setView }: QuestionFormProps) {
   const [title, setTitle] = useState<string>('');
   const [content, setContent] = useState<string>('');
 
-  const mutation = useMutation<QuestionPost, Error, QuestionPost>({
+  const mutation = useMutation<QuestionResponse, Error, QuestionPost>({
     mutationKey: ['question'],
     mutationFn: (payload: QuestionPost) => fetchQuestionPost(payload),
     onSuccess: (data) => {
       console.log('문의하기 성공:', data);
+      alert('요청사항이 정상적으로 접수되었습니다. 감사합니다!');
+      setView(null);
     },
     onError: (error) => {
       console.error('문의하기 실패:', error);
+      alert('요청사항 전송에 실패하였습니다');
     },
   });
 

--- a/src/interface/QuestionInterface.ts
+++ b/src/interface/QuestionInterface.ts
@@ -11,3 +11,9 @@ export interface QuestionResponse {
   data: null;
   success: boolean;
 }
+
+// 문의하기 모달창 닫기
+export interface QuestionFormProps {
+  title?: string | null;
+  setView: (view: React.ReactNode | null) => void;
+}

--- a/src/modal/NoteSendModal.tsx
+++ b/src/modal/NoteSendModal.tsx
@@ -12,7 +12,7 @@ function NoteSendModal({ closeModal }: { closeModal: () => void }) {
           />
           <p className="font-bold">쪽지 보내기</p>
         </div>
-        <NoteSendForm />
+        <NoteSendForm closeModal={closeModal} />
       </div>
     </div>
   );

--- a/src/pages/Question.tsx
+++ b/src/pages/Question.tsx
@@ -1,12 +1,13 @@
 import QuestionForm from '@/component/form/QuestionForm';
+import { QuestionFormProps } from '@/interface/QuestionInterface';
 
-function Question({ title }: { title: string }) {
+function Question({ title, setView }: QuestionFormProps) {
   return (
     <>
       <div className="w-full pb-5">
         <h2 className="font-bold text-lg">{title}</h2>
       </div>
-      <QuestionForm />
+      <QuestionForm setView={setView} />
     </>
   );
 }


### PR DESCRIPTION
- 문의하기 완료 시 '/profile' 페이지로 이동
- 문의하기 전송 성공 여부 alert()로 표시
- 쪽지 작성 후 쪽지 리스트 페이지로 이동
- 쪽지 및 문의하기 전송 여브 alert()로 표시